### PR TITLE
Fixed compatibility with Django version 1.5+

### DIFF
--- a/djobberbase/models.py
+++ b/djobberbase/models.py
@@ -15,6 +15,7 @@ from djobberbase.conf import settings as djobberbase_settings
 import datetime
 import uuid
 import time
+import django
 
 try:
     from hashlib import md5
@@ -133,7 +134,10 @@ class Job(models.Model):
     city = models.ForeignKey(City, verbose_name=_('City'), null=True, blank=True)
     outside_location = models.CharField(_('Outside location'), max_length=150, blank=True)
     #url of the company
-    url = models.URLField(verify_exists=False, max_length=150, blank=True)
+    if django.get_version() >= 1.5:
+        url = models.URLField(max_length=150, blank=True)
+    else:
+        url = models.URLField(verify_exists=False, max_length=150, blank=True)
     created_on = models.DateTimeField(_('Created on'), editable=False, \
                                         default=datetime.datetime.now())
     status = models.IntegerField(choices=JOB_STATUS_CHOICES, default=TEMPORARY)


### PR DESCRIPTION
verify_exists has been deprecated on Django version 1.5. This fix just adds compatibility checking the Django version first.
